### PR TITLE
add ability to globally disable all interaction with nginx

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -89,6 +89,9 @@ func mergeConfigs(configs ...*Configuration) *Configuration {
 		if !isZero(config.NginxSSLCertPath) {
 			newConfig.NginxSSLCertPath = config.NginxSSLCertPath
 		}
+		if !isZero(config.NginxDisabled) {
+			newConfig.NginxDisabled = config.NginxDisabled
+		}
 		if !isZero(config.NginxSSLDisabled) {
 			newConfig.NginxSSLDisabled = config.NginxSSLDisabled
 		}

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -12,6 +12,7 @@ func loadDefaultConfig() *Configuration {
 		NginxConfigDirectory:   "/etc/nginx/sites-enabled",
 		NginxHtpasswdDirectory: "/etc/nginx/htpasswd",
 		ServingDomain:          "example.com",
+		NginxDisabled:          false,
 		NginxSSLDisabled:       false,
 		NginxSSLCertPath:       "/etc/ssl/certs/oneill.crt",
 		NginxSSLKeyPath:        "/etc/ssl/private/oneill.pem",

--- a/config/types.go
+++ b/config/types.go
@@ -8,6 +8,7 @@ type Configuration struct {
 	NginxHtpasswdDirectory string                         `yaml:"nginx_htpasswd_directory,omitempty"`
 	ServingDomain          string                         `yaml:"serving_domain,omitempty"`
 	RegistryCredentials    map[string]RegistryCredentials `yaml:"registry_credentials"`
+	NginxDisabled          bool                           `yaml:"nginx_disabled"`
 	NginxSSLDisabled       bool                           `yaml:"nginx_ssl_disabled"`
 	NginxSSLCertPath       string                         `yaml:"nginx_ssl_cert"`
 	NginxSSLKeyPath        string                         `yaml:"nginx_ssl_key"`

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -8,6 +8,11 @@
 # see README.md for explanation of appropriate values for `definitions_uri`
 definitions_uri: "file:///etc/oneill/definitions"
 
+# If true, all nginx functionality will be completely disabled. Use this if
+# you're solely running containers that shouldn't be exposed to the internet
+# or if you're using some other tool for service discovery and routing.
+nginx_disabled: false
+
 # The directory to which nginx configuration files should be written. Note
 # that oneill expects to own this directory and will remove any files
 # contained within the folder if they don't match a running container.

--- a/main.go
+++ b/main.go
@@ -42,14 +42,19 @@ func main() {
 	runningContainers, err := containerdefs.ProcessContainerDefinitions(definitions, dockerClient)
 	exitOnError(err, "Unable to process container definitions")
 
-	err = nginxclient.ConfigureAndReload(config, runningContainers)
-	exitOnError(err, "Unable to configure and reload nginx")
+	// if nginx is disabled globally we just skip the configuration and reload steps entirely
+	if !config.NginxDisabled {
 
-	// sleep for a few seconds just to let any active requests finish up
-	// gracefully if possible. TODO: We should really only do this (same goes
-	// for reloading the nginx config) if something has actually changed.
-	logrus.Debug("Sleeping to allow active requests to finish gracefully")
-	time.Sleep(5 * time.Second)
+		err = nginxclient.ConfigureAndReload(config, runningContainers)
+		exitOnError(err, "Unable to configure and reload nginx")
+
+		// sleep for a few seconds just to let any active requests finish up
+		// gracefully if possible. TODO: We should really only do this (same goes
+		// for reloading the nginx config) if something has actually changed.
+		logrus.Debug("Sleeping to allow active requests to finish gracefully")
+		time.Sleep(5 * time.Second)
+
+	}
 
 	err = dockerClient.RemoveOldContainers(runningContainers)
 	exitOnError(err, "Unable to stop and remove old containers")


### PR DESCRIPTION
This goes part way to addressing #22.

We still need to add support for disabling nginx on a per-definition basis, but that work can happen independently of this PR.