### PR TITLE
allow nginx/proxying to be disabled on a per-container basis

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ A single container definition should contain the following data:
 subdomain: example-subdomain                  # required
 image: example/some-container                 # required
 tag: v123                                     # optional (default: "latest")
+nginx_disabled: false                         # optional (default: false)
 env:                                          # optional (default: [])
   - "EXAMPLE=example"
   - "URL=http://www.example.com"

--- a/containerdefs/types.go
+++ b/containerdefs/types.go
@@ -1,11 +1,12 @@
 package containerdefs
 
 type ContainerDefinition struct {
-	Subdomain string   `yaml:"subdomain"`
-	Image     string   `yaml:"image"`
-	Tag       string   `yaml:"tag"`
-	Env       []string `yaml:"env"`
-	Htpasswd  []string `yaml:"htpasswd"`
+	Subdomain     string   `yaml:"subdomain"`
+	Image         string   `yaml:"image"`
+	Tag           string   `yaml:"tag"`
+	NginxDisabled bool     `yaml:"nginx_disabled"`
+	Env           []string `yaml:"env"`
+	Htpasswd      []string `yaml:"htpasswd"`
 }
 
 type RunningContainerDefinition struct {

--- a/dockerclient/dockerclient.go
+++ b/dockerclient/dockerclient.go
@@ -320,6 +320,13 @@ func (d *dockerClient) ValidateImage(cd *containerdefs.ContainerDefinition) erro
 		return err
 	}
 
+	// if nginx/proxy support is disabled for this container then we can skip
+	// the final check for a single port, we don't care what it exposes in
+	// this case.
+	if cd.NginxDisabled {
+		return nil
+	}
+
 	// check that the image exposes exactly 1 port. For now oneill doesn't
 	// support containers unless they expose exactly one port, this is to make
 	// configuration and interaction with nginx much simpler. We may revise

--- a/nginxclient/nginxclient.go
+++ b/nginxclient/nginxclient.go
@@ -90,7 +90,9 @@ func removeIfRedundant(directory string, f os.FileInfo, rcs []*containerdefs.Run
 	// just return immediately and skip it.
 	for _, rc := range rcs {
 		if f.Name() == rc.Name {
-			return nil
+			if !rc.ContainerDefinition.NginxDisabled {
+				return nil
+			}
 		}
 	}
 
@@ -206,6 +208,12 @@ func writeNewFiles(d string, f cfWriter, c *config.Configuration, rcs []*contain
 
 	// loop over and write a configuration file for every running container
 	for _, rc := range rcs {
+		// if this container definition has explicitly disabled nginx support
+		// then we just skip it
+		if rc.ContainerDefinition.NginxDisabled {
+			continue
+		}
+		// call the passed in cfWriter function on each container
 		err = f(c, rc)
 		if err != nil {
 			return err


### PR DESCRIPTION
closes #22 

container definitions now support an optional flag `nginx_disabled` that when `true` disables exposing that container on a subdomain via nginx.