### PR TITLE
only reload nginx config when something actually changes

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,8 +3,6 @@
 package main
 
 import (
-	"time"
-
 	"github.com/Sirupsen/logrus"
 
 	"github.com/rehabstudio/oneill/config"
@@ -49,16 +47,8 @@ func main() {
 
 	// if nginx is disabled globally we just skip the configuration and reload steps entirely
 	if !config.NginxDisabled {
-
 		err = nginxclient.ConfigureAndReload(config, runningContainers)
 		exitOnError(err, "Unable to configure and reload nginx")
-
-		// sleep for a few seconds just to let any active requests finish up
-		// gracefully if possible. TODO: We should really only do this (same goes
-		// for reloading the nginx config) if something has actually changed.
-		logrus.Debug("Sleeping to allow active requests to finish gracefully")
-		time.Sleep(5 * time.Second)
-
 	}
 
 	err = dockerClient.RemoveOldContainers(runningContainers)

--- a/nginxclient/types.go
+++ b/nginxclient/types.go
@@ -7,7 +7,7 @@ import (
 
 // cfWriter defines a function type that is used for writing nginx
 // configuration or htpasswd files to disk
-type cfWriter func(*config.Configuration, *containerdefs.RunningContainerDefinition) error
+type cfWriter func(*config.Configuration, *containerdefs.RunningContainerDefinition) (bool, error)
 
 // templateContext is a simple struct used to contain context
 // data for use when rendering templates


### PR DESCRIPTION
closes #26 when merged

when any nginx config file or htpasswd file is written or removed the nginx configuration will be reloaded. If nothing changes the reload is skipped.