### PR TITLE
added initial support for specifying env vars using regular yaml syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 config.yaml
+definitions.yaml
 oneill
 nginxclient/bindata.go

--- a/README.md
+++ b/README.md
@@ -194,10 +194,18 @@ also be added to a container definition.
 
 ```yaml
 # add custom environment variables that will be passed into the container when
-# started. This value is optional (default: []).
+# started. This value is optional (default: []). Note that any YAML data is
+# valid here, if the value is not a simple string it will be serialised to JSON
+# before passing to the new container.
 env:
-  - "EXAMPLE=example"
-  - "URL=http://www.example.com"
+  EXAMPLE: example
+  URL: http://www.example.com
+  SOMELIST:
+    - something
+    - some other thing
+  SOMEMAP:
+    somekey: somevalue
+    someotherkey: someothervalue
 
 # should persistence be enabled for this container? default off as we don't
 # want to encourage people to use local persistence (whilst acknowledging that

--- a/containerdefs/definitions.go
+++ b/containerdefs/definitions.go
@@ -31,7 +31,7 @@ type ContainerDefinition struct {
 	// passed to new containers at runtime. Variables set here will override
 	// environment variables set anywhere else (including those set by oneill
 	// itself), so use with caution.
-	Env []string `yaml:"env"`
+	Env dockerclient.Env `yaml:"env"`
 
 	// should persistence be enabled for this container? default off as we
 	// don't want to encourage people to use persistence (whilst acknowledging


### PR DESCRIPTION
Environment variables are internally turned into k=v pairs and the value of each item will be jsonified if necessary (if it's not a string)